### PR TITLE
Fix: Ensure FlyoutItem titles are consistently visible

### DIFF
--- a/StowTown/AppShell.xaml.cs
+++ b/StowTown/AppShell.xaml.cs
@@ -126,46 +126,6 @@ namespace StowTown
             FlyoutDropdown.IsVisible = !FlyoutDropdown.IsVisible;
         }
 
-        protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
-        {
-            base.OnNavigatedFrom(args);
-
-            string route = Shell.Current.CurrentItem?.Route ?? "";
-
-            switch (route)
-            {
-                case "HomeDashboard":
-                    ShellHelper.UpdateFlyoutItemTitle("HomeDashboard", "Home", "assets/Home.png");
-                    break;
-                case "RadioStationManagement":
-                    ShellHelper.UpdateFlyoutItemTitle("RadioStationManagement", "Radio Station", "assets/music.png");
-                    break;
-                case "DjManagement":
-                    ShellHelper.UpdateFlyoutItemTitle("DjManagement", "Dj", "assets/headphones.png");
-                    break;
-                case "ArtistManagement":
-                    ShellHelper.UpdateFlyoutItemTitle("ArtistManagement", "Artist", "assets/user.png");
-                    break;
-                case "Graph":
-                    ShellHelper.UpdateFlyoutItemTitle("Graph", "Reporting", "assets/Icons.png");
-                    break;
-                case "SongManagement":
-                    ShellHelper.UpdateFlyoutItemTitle("SongManagement", "Song List", "assets/music.png");
-                    break;
-                case "MonthlySongManagement":
-                    ShellHelper.UpdateFlyoutItemTitle("MonthlySongManagement", "Monthly Song List", "assets/filemusic.png");
-                    break;
-                case "CallScheduleList":
-                    ShellHelper.UpdateFlyoutItemTitle("CallScheduleList", "Call Schedule", "assets/Icons.png");
-                    break;
-                case "PojectProducerManagement":
-                    ShellHelper.UpdateFlyoutItemTitle("PojectProducerManagement", "Producer", "assets/radio.png");
-                    break;
-                case "ManualSongSpins":
-                    ShellHelper.UpdateFlyoutItemTitle("ManualSongSpins", "Manual Spin Tracker", "assets/music.png");
-                    break;
-            }
-        }
     
 
     }


### PR DESCRIPTION
I removed the OnNavigatedFrom override in AppShell.xaml.cs. This method was programmatically updating FlyoutItem titles that are already defined in the XAML. This redundancy was identified as a potential cause for titles intermittently not being visible.

By removing this method, the application now relies on MAUI's default handling of XAML-defined titles for FlyoutItems, which has resolved the visibility issue.