### PR TITLE
Fix: FlyoutItem titles disappearing after Alt+Tab

### DIFF
--- a/StowTown/App.xaml.cs
+++ b/StowTown/App.xaml.cs
@@ -1,4 +1,8 @@
-﻿namespace StowTown
+﻿using Microsoft.Maui.Controls;
+using StowTown;
+using System.Diagnostics;
+
+namespace StowTown
 {
     public partial class App : Application
     {
@@ -30,6 +34,34 @@
 
         }
 
+        protected override Window CreateWindow(IActivationState? activationState)
+        {
+            Window window = base.CreateWindow(activationState);
+
+            window.Activated += OnWindowActivated;
+            // Optionally, you can also subscribe to Deactivated if needed for logging or other logic
+            // window.Deactivated += OnWindowDeactivated;
+
+            return window;
+        }
+
+        private void OnWindowActivated(object sender, EventArgs e)
+        {
+            Debug.WriteLine("Window Activated event fired.");
+            if (Application.Current?.MainPage is AppShell appShell)
+            {
+                appShell.RefreshAllFlyoutTitles();
+            }
+            else
+            {
+                Debug.WriteLine("AppShell instance not found on MainPage for refreshing titles.");
+            }
+        }
+
+        // Optional: Handler for Deactivated event if you added it
+        // private void OnWindowDeactivated(object sender, EventArgs e)
+        // {
+        //     Debug.WriteLine("Window Deactivated event fired.");
+        // }
     }
 }
-    

--- a/StowTown/AppShell.xaml.cs
+++ b/StowTown/AppShell.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.ApplicationModel.Communication;
 using StowTown.HelperService;
+using System.Diagnostics;
 using StowTown.Models;
 using StowTown.Pages.ArtistsManagements;
 using StowTown.Pages.CallHistory;
@@ -126,6 +127,62 @@ namespace StowTown
             FlyoutDropdown.IsVisible = !FlyoutDropdown.IsVisible;
         }
 
+        protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+        {
+            base.OnNavigatedFrom(args);
+
+            string route = Shell.Current.CurrentItem?.Route ?? "";
+
+            switch (route)
+            {
+                case "HomeDashboard":
+                    ShellHelper.UpdateFlyoutItemTitle("HomeDashboard", "Home", "assets/Home.png");
+                    break;
+                case "RadioStationManagement":
+                    ShellHelper.UpdateFlyoutItemTitle("RadioStationManagement", "Radio Station", "assets/music.png");
+                    break;
+                case "DjManagement":
+                    ShellHelper.UpdateFlyoutItemTitle("DjManagement", "Dj", "assets/headphones.png");
+                    break;
+                case "ArtistManagement":
+                    ShellHelper.UpdateFlyoutItemTitle("ArtistManagement", "Artist", "assets/user.png");
+                    break;
+                case "Graph":
+                    ShellHelper.UpdateFlyoutItemTitle("Graph", "Reporting", "assets/Icons.png");
+                    break;
+                case "SongManagement":
+                    ShellHelper.UpdateFlyoutItemTitle("SongManagement", "Song List", "assets/music.png");
+                    break;
+                case "MonthlySongManagement":
+                    ShellHelper.UpdateFlyoutItemTitle("MonthlySongManagement", "Monthly Song List", "assets/filemusic.png");
+                    break;
+                case "CallScheduleList":
+                    ShellHelper.UpdateFlyoutItemTitle("CallScheduleList", "Call Schedule", "assets/Icons.png");
+                    break;
+                case "PojectProducerManagement":
+                    ShellHelper.UpdateFlyoutItemTitle("PojectProducerManagement", "Producer", "assets/radio.png");
+                    break;
+                case "ManualSongSpins":
+                    ShellHelper.UpdateFlyoutItemTitle("ManualSongSpins", "Manual Spin Tracker", "assets/music.png");
+                    break;
+            }
+        }
+
+        public void RefreshAllFlyoutTitles()
+        {
+            Debug.WriteLine("AppShell.RefreshAllFlyoutTitles called due to window activation.");
+            ShellHelper.UpdateFlyoutItemTitle("HomeDashboard", "Home", "assets/Home.png");
+            ShellHelper.UpdateFlyoutItemTitle("RadioStationManagement", "Radio Station", "assets/music.png");
+            ShellHelper.UpdateFlyoutItemTitle("DjManagement", "Dj", "assets/headphones.png");
+            ShellHelper.UpdateFlyoutItemTitle("ArtistManagement", "Artist", "assets/user.png");
+            ShellHelper.UpdateFlyoutItemTitle("Graph", "Reporting", "assets/Icons.png");
+            // Note: "Call History" FlyoutItem has no route, so it cannot be refreshed by ShellHelper.UpdateFlyoutItemTitle.
+            ShellHelper.UpdateFlyoutItemTitle("SongManagement", "Song List", "assets/music.png");
+            ShellHelper.UpdateFlyoutItemTitle("MonthlySongManagement", "Monthly Song List", "assets/filemusic.png");
+            ShellHelper.UpdateFlyoutItemTitle("CallScheduleList", "Call Schedule", "assets/Icons.png");
+            ShellHelper.UpdateFlyoutItemTitle("PojectProducerManagement", "Producer", "assets/radio.png");
+            ShellHelper.UpdateFlyoutItemTitle("ManualSongSpins", "Manual Spin Tracker", "assets/music.png");
+        }
     
 
     }


### PR DESCRIPTION
I've implemented a mechanism to refresh FlyoutItem titles when the application window regains focus. This addresses an issue where titles would sometimes disappear after you switch applications using Alt+Tab.

Changes include:
- I added a RefreshAllFlyoutTitles() method to AppShell.xaml.cs that explicitly resets the titles of known FlyoutItems using the existing ShellHelper.UpdateFlyoutItemTitle method.
- I overrode the CreateWindow() method in App.xaml.cs to subscribe to the Window.Activated event.
- When the Activated event fires, the RefreshAllFlyoutTitles() method in AppShell is called, ensuring titles are correctly displayed.
- I restored the OnNavigatedFrom method in AppShell.xaml.cs to its original state as its removal did not fix the issue and it might handle other UI update scenarios.