### PR TITLE
Feat: Add loader to Artist Management page

### DIFF
--- a/StowTown/Pages/ArtistsManagements/ArtistManagement.xaml
+++ b/StowTown/Pages/ArtistsManagements/ArtistManagement.xaml
@@ -5,11 +5,12 @@
              Title="" BackgroundColor="#E5EFEE">
 
     <ContentPage.Content>
-        <ScrollView Orientation="Both" HorizontalScrollBarVisibility="Always" VerticalScrollBarVisibility="Always">
-            <VerticalStackLayout >
-                <Grid RowDefinitions="Auto,*,Auto">
-                    <Grid Grid.Row="0"  ColumnDefinitions="*,Auto">
-                        <Label Text="Artist Management"
+        <Grid> <!-- New Grid -->
+            <ScrollView Orientation="Both" HorizontalScrollBarVisibility="Always" VerticalScrollBarVisibility="Always">
+                <VerticalStackLayout >
+                    <Grid RowDefinitions="Auto,*,Auto">
+                        <Grid Grid.Row="0"  ColumnDefinitions="*,Auto">
+                            <Label Text="Artist Management"
  FontSize="26"
  FontAttributes="Bold"
  VerticalOptions="Center"
@@ -199,5 +200,15 @@
                 </VerticalStackLayout>
             </VerticalStackLayout>
         </ScrollView>
+
+            <ActivityIndicator x:Name="artistLoader"
+                               IsRunning="False"
+                               IsVisible="False"
+                               HorizontalOptions="Center"
+                               VerticalOptions="Center"
+                               Color="Black"
+                               HeightRequest="50"
+                               WidthRequest="50"/>
+        </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/StowTown/Pages/ArtistsManagements/ArtistManagement.xaml.cs
+++ b/StowTown/Pages/ArtistsManagements/ArtistManagement.xaml.cs
@@ -54,9 +54,18 @@ public partial class ArtistManagement : ContentPage
     }
     public void LoadData()
     {
-        try
+        if (artistLoader != null) // Check if loader exists
         {
-            using (var context = new StowTownDbContext())
+            artistLoader.IsVisible = true;
+            artistLoader.IsRunning = true;
+        }
+
+        try // Outer try for the finally block
+        {
+            // Existing try-catch block for database operations
+            try
+            {
+                using (var context = new StowTownDbContext())
             {
                 var artistList = context.ArtistGroups
                     .Where(a => a.IsDeleted != true )
@@ -103,9 +112,18 @@ public partial class ArtistManagement : ContentPage
                 LoadCurrentPage();
             }
         }
-        catch (Exception ex)
+            catch (Exception ex)
+            {
+                DisplayAlert("Error", ex.Message, "OK");
+            }
+        }
+        finally
         {
-            DisplayAlert("Error", ex.Message, "OK");
+            if (artistLoader != null) // Check if loader exists
+            {
+                artistLoader.IsVisible = false;
+                artistLoader.IsRunning = false;
+            }
         }
     }
 


### PR DESCRIPTION
I've implemented an ActivityIndicator on the Artist Management page to provide you with visual feedback during data loading.

Here's what I changed:
- I added an ActivityIndicator (artistLoader) to ArtistManagement.xaml, which will be overlaid on the content area.
- I modified the LoadData() method in ArtistManagement.xaml.cs so that:
  - The artistLoader becomes visible and starts its animation before any data fetching begins.
  - I made sure the artistLoader is hidden and its animation stops after data loading completes or if an error occurs. I used a try/finally block for this.

This should improve your experience by clearly showing that the application is working when you navigate to the Artist page, especially since it can take some time to load the data.