### PR TITLE
Fix: FlyoutItem titles disappearing on Alt+Tab (Windows) via Padding …

### DIFF
--- a/StowTown/App.xaml.cs
+++ b/StowTown/App.xaml.cs
@@ -45,7 +45,7 @@ namespace StowTown
 
         private void OnWindowActivated(object sender, EventArgs e)
         {
-            Debug.WriteLine("Window Activated event fired. Attempting to invalidate AppShell measure.");
+            Debug.WriteLine("Window Activated event fired. Attempting to refresh AppShell layout via Padding.");
 
             // Ensure execution on the main UI thread.
             // While Activated event should be on UI thread, explicit dispatching is safer for UI manipulations.
@@ -53,12 +53,17 @@ namespace StowTown
             {
                 if (Application.Current?.MainPage is AppShell appShell)
                 {
-                    appShell.InvalidateMeasure();
-                    Debug.WriteLine("AppShell.InvalidateMeasure() called.");
+                    var originalPadding = appShell.Padding;
+                    // Apply a tiny, likely imperceptible change to Padding to trigger a layout update.
+                    // Adding to Left; any component or a new Thickness object would work.
+                    appShell.Padding = new Thickness(originalPadding.Left + 0.001, originalPadding.Top, originalPadding.Right, originalPadding.Bottom);
+                    // Immediately revert to the original padding.
+                    appShell.Padding = originalPadding;
+                    Debug.WriteLine("AppShell.Padding temporarily modified and reverted to trigger UI refresh.");
                 }
                 else
                 {
-                    Debug.WriteLine("AppShell instance not found on MainPage for InvalidateMeasure.");
+                    Debug.WriteLine("AppShell instance not found on MainPage for Padding modification.");
                 }
             });
         }


### PR DESCRIPTION
…toggle

I've resolved an issue where FlyoutItem titles would disappear after switching applications using Alt+Tab on Windows when the Shell's FlyoutBehavior is set to Locked.

This corrected fix addresses a compilation error from a previous attempt (CS0122 for InvalidateMeasure) by using an alternative method to force a UI refresh.

The fix involves:
- Overriding the CreateWindow method in App.xaml.cs.
- Subscribing to the Window.Activated event.
- In the event handler, when the window is activated:
  - Temporarily modifying the Padding property of the AppShell instance (e.g., by adding a minuscule value to one of its components and then immediately reverting to the original padding).
  - This action is dispatched to the main UI thread.

This padding toggle technique triggers a layout recalculation and redraw of the AppShell, ensuring FlyoutItem titles are consistently rendered after application focus changes.